### PR TITLE
Prevent conflict between variable names in Resource.save! – this was cau...

### DIFF
--- a/lib/ns_connector/resource.rb
+++ b/lib/ns_connector/resource.rb
@@ -128,7 +128,7 @@ class NSConnector::Resource
 	# Returns:: true
 	def save!
 		# Convert all of our sublist objects to hashes
-		sublists = Hash[@sublist_store.map {|sublist_id, objects|
+		sublist_data = Hash[@sublist_store.map {|sublist_id, objects|
 			[sublist_id, objects.map {|object|
 				object.to_hash
 			}]
@@ -139,7 +139,7 @@ class NSConnector::Resource
 			:type_id => type_id,
 			:fields => fields,
 			:data => @store,
-			:sublists => sublists,
+			:sublists => sublist_data,
 		)
 
 		# If we got this far, we're probably in NetSuite

--- a/spec/resource_spec.rb
+++ b/spec/resource_spec.rb
@@ -91,10 +91,6 @@ describe PseudoResource do
 			@p.notes << note_item1
 			@p.notes << note_item2
 
-			# Replace them, backways to test.
-			SubList.should_receive(:save!).
-				and_return([note_item2, note_item1])
-
 			Restlet.should_receive(:execute!).
 				with({
 					:action => 'create',
@@ -110,6 +106,11 @@ describe PseudoResource do
 				}).
 				once.
 				and_return(ns_reply)
+
+			# Replace them, backways to test.
+			SubList.should_receive(:save!).
+				with([note_item1, note_item2], @p, :notes, [:line]).
+				and_return([note_item2, note_item1])
 
 			expect(@p.save!).to eql(true)
 


### PR DESCRIPTION
This error was causing a nasty error a nasty error when we'd successfully saved a sublist, but on retrieving it would send the sublist data that it was going to push up in the fields column, instead of the array of sublist fields that we needed to.

This is because "sublists" should only be used to access that particular class' list of sublists and field names for each one.

To fix it, I just changed the name of the sublist data that we're pushing up to NS.

Extra detail added to resource_spec to test that we're sending the correct parameters to it.
