### PR TITLE
Custom User Agent functionality

### DIFF
--- a/lib/ns_connector/restlet.rb
+++ b/lib/ns_connector/restlet.rb
@@ -44,6 +44,7 @@ module NSConnector::Restlet
 
 		request['Content-Type'] = 'application/json'
 		request['Authorization'] = NSConnector::Restlet.auth_header
+		request['User-Agent'] = NSConnector::Config[:user_agent] if NSConnector::Config[:user_agent]
 
 		begin
 			options[:code] = restlet_code

--- a/spec/restlet_spec.rb
+++ b/spec/restlet_spec.rb
@@ -19,7 +19,8 @@ describe Restlet do
 				:body => expected_body,
 				:headers => {
 					'Authorization' => /^NLAuth/,
-					'Content-Type'=>'application/json'
+					'Content-Type'=>'application/json',
+					'User-Agent' => 'Restlet Test UA'
 				}
 			}
 

--- a/spec/support/mock_data.rb
+++ b/spec/support/mock_data.rb
@@ -6,5 +6,6 @@ def valid_config
 		:password    => "pass\0word",
 		:role        => '123',
 		:restlet_url => 'https://netsuite:1234/restlet',
+		:user_agent  => 'Restlet Test UA'
 	}
 end


### PR DESCRIPTION
Allows custom User Agent headers to be defined in ns_connector which can be used as a column or filter in the API log on Netsuite's side.
